### PR TITLE
Shorten URL in tooltip to "[doc]"

### DIFF
--- a/test/demo/es6/.tern-project
+++ b/test/demo/es6/.tern-project
@@ -1,0 +1,6 @@
+{
+  "plugins": {
+    "node": {},
+    "es_modules": {}
+  }
+}

--- a/test/demo/es6/index.js
+++ b/test/demo/es6/index.js
@@ -1,0 +1,22 @@
+// Tern can do ECMAScript 6 (2015) too!
+
+// Imports and exports work. You can complete module names, and
+// jump to the definition of things defined in modules.
+
+// (Press ctrl-. on `List` to jump to the class definition)
+import {List} from "./list"
+
+import * as myMath from "./mymath"
+
+const l = List.of(3, 4, 5)
+for (let elt of l.map(x => x * 2)) {
+  // Tern knows that `elt` is a number!
+  let output = myMath.halve(elt)
+  console.log(output)
+}
+
+// Raw template string
+let raw = String.raw`\n`
+
+// Default arguments
+Array.of(1, 2, 3, 4).find(x => x % 3 == 0)

--- a/test/demo/es6/list.js
+++ b/test/demo/es6/list.js
@@ -1,0 +1,22 @@
+export class List {
+  constructor(head, tail) {
+    this.head = head
+    this.tail = tail
+  }
+
+  static of(...elements) {
+    let result = null
+    for (let i = elements.length - 1; i >= 0; i--)
+      result = new List(elements[i], result)
+    return result
+  }
+
+  map(f) {
+    return new List(f(this.head), this.tail && this.tail.map(f))
+  }
+
+  *[Symbol.iterator]() {
+    for (let pos = this; pos; pos = pos.tail)
+      yield pos.head
+  }
+}

--- a/test/demo/es6/mymath.js
+++ b/test/demo/es6/mymath.js
@@ -1,0 +1,3 @@
+export const PI = 3
+
+export const halve = x => x / 2

--- a/utils/renderer.py
+++ b/utils/renderer.py
@@ -87,7 +87,7 @@ def get_html_message_from_ftype(ftype, argpos):
   template_data = {
     'style': style,
     'func_signature': hint_line(func_signature),
-    'doc_link': hint_line(link(ftype['url'])),
+    'doc_link': hint_line(link(ftype['url'], '[docs]')),
     'doc': hint_line(doc)
   }
 
@@ -118,17 +118,27 @@ def get_description_message(useHTML, type, doc=None, url=None):
 
 
 def maybe(fn):
-  def maybe_fn(arg):
-    return fn(arg) if arg else ''
+  def maybe_fn(arg, *args, **kwargs):
+    return fn(arg, *args, **kwargs) if arg else ''
   return maybe_fn
 
+
 @maybe
-def link(url):
-  return '<a href={url}>{url}</a>'.format(url=url)
+def link(url, linkText='{url}'):
+  """Returns a link HTML string.
+
+  The string is an &lt;a&gt; tag that links to the given url.
+  If linkText is not provided, the link text will be the url.
+  """
+
+  template = '<a href={url}>' + linkText + '</a>'
+  return template.format(url=url)
+
 
 @maybe
 def hint_line(txt):
   return '<div class="hint-line-content">{txt}</div>'.format(txt=txt)
+
 
 def go_to_url(url=None):
   if url:


### PR DESCRIPTION
Hi Marijn,

This is a small one, just shortening the tooltip URL to "[doc]". This addresses the comment by PixelT [here](https://github.com/ternjs/tern_for_sublime/issues/68). It was either this or increase the max width, and I thought this was better because it matches the online demo at [ternjs.net](http://ternjs.net).

I would have done this directly, but I forgot I was still committing to my fork. Figured I'd make a pull request while I'm here, in case there was a reason you wanted to keep the full text of the URL.