### PR TITLE
Fix TypeError with tern_arguments in Popen

### DIFF
--- a/tern.py
+++ b/tern.py
@@ -169,7 +169,7 @@ def start_server(project):
   if platform.system() == "Darwin":
     env = os.environ.copy()
     env["PATH"] += ":/usr/local/bin"
-  proc = subprocess.Popen(tern_command + tern_arguments, cwd=project.dir, env=env,
+  proc = subprocess.Popen(tern_arguments, executable=tern_command, cwd=project.dir, env=env,
                           stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                           stderr=subprocess.STDOUT, shell=windows)
   output = ""


### PR DESCRIPTION
Fixes `TypeError: Can't convert 'list' object to str implicitly` when attempting to spawn the `tern` child process with custom arguments.