### PR TITLE
fix: usr: typo alert when selecting variables in windows with project…

### DIFF
--- a/tern.py
+++ b/tern.py
@@ -548,7 +548,7 @@ class TernSelectVariable(sublime_plugin.TextCommand):
     shown_error = False
     regions = []
     for ref in data["refs"]:
-      if ref["file"] != file:
+      if ref["file"].replace('\\','/') != file.replace('\\','/'):
         if not shown_error:
           sublime.error_message("Not all uses of this variable are file-local. Selecting only local ones.")
           shown_error = True


### PR DESCRIPTION
FIX bug in selecting variables in windows platform due to the windows type path.

Signed-off-by: Richard Lea <chigix@zoho.com>