### PR TITLE
Fix installation on windows

### DIFF
--- a/tern.py
+++ b/tern.py
@@ -2,6 +2,7 @@
 
 import sublime, sublime_plugin
 import os, sys, platform, subprocess, webbrowser, json, re, time, atexit
+from subprocess import CalledProcessError
 try:
   # python 2
   from utils.renderer import create_renderer
@@ -608,13 +609,15 @@ def plugin_loaded():
           "Yes, install."):
         try:
           if hasattr(subprocess, "check_output"):
-            subprocess.check_output(["npm", "install"], cwd=plugin_dir)
+            subprocess.check_output(["npm", "--loglevel=silent", "install"], cwd=plugin_dir, shell=windows)
           else:
-            subprocess.check_call(["npm", "install"], cwd=plugin_dir)
-        except (IOError, OSError) as e:
+            subprocess.check_call(["npm", "--loglevel=silent", "install"], cwd=plugin_dir, shell=windows)
+        except (IOError, OSError, CalledProcessError) as e:
           msg = "Installation failed. Try doing 'npm install' manually in " + plugin_dir + "."
-          if hasattr(e, "output"):
-            msg += " Error message was:\n\n" + e.output
+          if hasattr(e, "output") and e.output is not None:
+            msg += "\nError message was:\n\n" + e.output
+          if hasattr(e, "returncode"):
+            msg += "\nReturn code was: " + str(e.returncode)
           sublime.error_message(msg)
           return
     tern_command = ["node",  os.path.join(plugin_dir, "node_modules/tern/bin/tern"), "--no-port-file"]


### PR DESCRIPTION
I noticed different issues regarding ternjs install on windows, I had problems myself, the default answer in the issues is "manually do npm install"

This is not a terrible workaround, but still, *is a workaround*

Using `shell=True` on windows let the installer run smoothly (it's a PATH problem, without shell), I also added `loglevel=silent` on npm to avoid it returning code 1 because it couldn't write on STDERR/STDOUT

I am no python programmer, so don't expect a classy PR... it's just a bugfix one