### PR TITLE
#143: Changed command menu to point at the correct default keymap file

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -65,7 +65,7 @@
                                 "caption": "Key Bindings – Default",
                                 "command": "open_file", "args":
                                 {
-                                    "file": "${packages}/tern_for_sublime/Tern.sublime-keymap"
+                                    "file": "${packages}/tern_for_sublime/Default.sublime-keymap"
                                 }
                             },
                             {


### PR DESCRIPTION
The 'Key Bindings - Default' option in the tern package menu points at the wrong file. I updated the Main.sublime-menu file to point it at Default.sublime-keymap instead of the Tern.sublime-keymap.

Changing the filename would work too, of course.

This resolves #143