### PR TITLE
Add tern_inhibit_word_completions config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ plugins for a project. See the [Tern docs][docs] for details.
 
 [docs]: http://ternjs.net/doc/manual.html#configuration
 
+`tern_inhibit_word_completions` (boolean, default to false)
+If true, Prevents Sublime Text from adding its word completions to the completion list after all plugins have been processed. This consists of any word in the current document that is longer than 3 characters.
+
 ### Automatically Showing Completions
 
 Add `{"selector": "source.js", "characters": "."}` to your

--- a/Tern.sublime-settings
+++ b/Tern.sublime-settings
@@ -4,5 +4,6 @@
     "tern_argument_completion": false,
     // Used to get auto completion for unsaved buffers
     // By default, this folder is inside Packages/tern_for_sublime/
-    "tern_default_project_dir": "default_project_dir"
+    "tern_default_project_dir": "default_project_dir",
+    "tern_inhibit_word_completions": false
 }

--- a/tern.py
+++ b/tern.py
@@ -66,8 +66,12 @@ class Listeners(sublime_plugin.EventListener):
 
     if not fresh:
       completions = [c for c in completions if c[1].startswith(prefix)]
-    return completions
 
+    flags = 0;
+    if get_setting("tern_inhibit_word_completions", False):
+      flags |= sublime.INHIBIT_WORD_COMPLETIONS
+
+    return (completions, flags)
 
 class ProjectFile(object):
   def __init__(self, name, view, project):


### PR DESCRIPTION
It doesn't make sense to have buffer completions when `tern` is configured correctly and providing accurate file and project-level completions.

This PR makes the plugin configurable to allow buffer-based completions to be disabled.

Docs for functionality: 

> `([[trigger, contents], ...], flags)`
> Basically the same as above but wrapped in a 2-sized tuple. The second element, the flags, may be a bitwise OR combination of these flags:
>
>    `sublime.INHIBIT_WORD_COMPLETIONS`
>    Prevents Sublime Text from adding its word completions to the completion list after all plugins have been processed. This consists of any word in the current document that is longer than 3 characters.


http://docs.sublimetext.info/en/latest/reference/api.html#sublime_plugin.EventListener.on_query_completions
