### PR TITLE
Fixed tern process opening

### DIFF
--- a/tern.py
+++ b/tern.py
@@ -174,6 +174,10 @@ def start_server(project):
   if platform.system() == "Darwin":
     env = os.environ.copy()
     env["PATH"] += ":/usr/local/bin"
+  
+  if not isinstance(tern_command, list):
+    tern_command = [tern_command]
+    
   proc = subprocess.Popen(tern_command + tern_arguments, cwd=project.dir, env=env,
                           stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                           stderr=subprocess.STDOUT, shell=windows)


### PR DESCRIPTION
I don't know how it managed to work before, because on my system i always have `tern_command` as a string, that may not be concatenated with a list.